### PR TITLE
Wrap exceptions from preprocessor with gulp-util's PluginError

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,21 +2,31 @@ var _     = require('lodash');
 var map   = require('map-stream');
 var pp    = require('preprocess');
 var path  = require('path');
+var util  = require('gulp-util');
 
 module.exports = function (context, options) {
   function ppStream(file, callback) {
-    var contents, extension;
+    var contents, extension, err;
 
     // TODO: support streaming files
     if (file.isNull()) return callback(null, file); // pass along
-    if (file.isStream()) return callback(new Error("gulp-preprocess: Streaming not supported"));
+    if (file.isStream()) return callback(new util.PluginError("gulp-preprocess", "Streaming not supported"));
 
     context.NODE_ENV = context.NODE_ENV || 'development';
-    contents = file.contents.toString('utf8');
-    contents = pp.preprocess(contents, context, options);
-    file.contents = new Buffer(contents);
 
-    callback(null, file);
+    try {
+      contents = file.contents.toString('utf8');
+      contents = pp.preprocess(contents, context, options);
+      file.contents = new Buffer(contents);
+    } catch (error) {
+      err = new util.PluginError("gulp-preprocess", error);
+    }
+
+    if (err == null) {
+      callback(null, file);
+    } else {
+      callback(err);
+    }
   }
 
   return map(ppStream);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "lodash": "^3.10.1",
     "map-stream": "0.1.x",
-    "preprocess": "^3.0.2"
+    "preprocess": "^3.0.2",
+    "gulp-util": "^3.0.6"
   },
   "devDependencies": {
     "gulp-util": "^3.0.6",


### PR DESCRIPTION
Better error reporting through plumber and the like.
